### PR TITLE
add Autoformer (paper&code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ List of state of the art papers focus on deep learning and resources, code and e
 
 ### 2021
 
+- [Autoformer: Decomposition Transformers with Auto-Correlation for Long-Term Series Forecasting](https://arxiv.org/abs/2106.13008)
+
+  - Haixu Wu, et al.
+  - [[Code](https://github.com/thuml/Autoformer)]
+
 - [Long Range Probabilistic Forecasting in Time-Series using High Order Statistics](https://arxiv.org/pdf/2111.03394.pdf)
 
   - Prathamesh Deshpande, et al.


### PR DESCRIPTION
Hi, @Alro10 

Recently I've discovered new time-series forecasting paper, titled 'Autoformer', that was accepted by [NIPS 2021](https://nips.cc/Conferences/2021/Schedule?showEvent=28217)

Please review and approve this PR if it is useful.

Thanks.